### PR TITLE
Update latest-release-notes

### DIFF
--- a/extra/latest-release-notes
+++ b/extra/latest-release-notes
@@ -4,3 +4,5 @@ see [release note](<%= pkg.repository.github %>/releases/tag/<%= pkg.version %>)
 For running:
 
 - Download latest version from [<%= pkg.version %>](<%= pkg.repository.github %>/releases/tag/<%= pkg.version %>)
+
+[![Build Status](https://travis-ci.org/<%= pkg.repository.github.replace(/http:\/\/github.com\//,"") %>.svg?branch=master)](https://travis-ci.org/<%= pkg.repository.github %>)


### PR DESCRIPTION
Added Travis CI badge by using GitHub repository url from `package.json`